### PR TITLE
Fix network name set and cmake pkgconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(JAY_BUILD_DOCS "Build jay documentation." OFF)
 # ============================================================================================
 
 
+include(FindPkgConfig)
 #Fing Canary
 if(NOT TARGET canary::canary)
   find_package(canary QUIET)

--- a/include/jay/network.hpp
+++ b/include/jay/network.hpp
@@ -56,7 +56,7 @@ public:
   std::set<jay::name> get_name_set()
   {
     std::shared_lock lock{ network_mtx_ };
-    std::set<jay::name> set{ name_addr_map_.size() };
+    std::set<jay::name> set{};
     for (auto &pair : name_addr_map_) { set.insert(pair.first); }
     return set;
   }


### PR DESCRIPTION
## Summary
- correctly initialize name set in `jay::network`
- ensure CMake can use pkg-config by loading the module

## Testing
- `cmake ..` *(fails: required package canary not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d48fdb008320a14263daaef34017