### PR TITLE
Add tests for network name set and transport protocol

### DIFF
--- a/include/jay/transport_protocol.hpp
+++ b/include/jay/transport_protocol.hpp
@@ -197,7 +197,7 @@ private:
   {
     while (s.next_seq <= s.total_packets && count--) {
       frame fr;
-      fr.header.pgn(PGN_TP_CM);
+      fr.header.pgn(PGN_TP_DT);
       fr.header.pdu_specific(s.dest_sa);
       fr.header.source_address(s.src_sa);
       fr.header.payload_length(8);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(${TEST_EXECUTABLE_NAME} main.cpp
     network_test.cpp
     network_manager_test.cpp
     name_test.cpp
+    transport_protocol_test.cpp
 )
 
 #

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -146,3 +146,16 @@ TEST(Jay_Network_Test, Jay_Network_Search_Test)
   ASSERT_EQ(j1939_network.find_address(0, 0, true), 0);
   ASSERT_EQ(j1939_network.find_address(controller, 0, true), address + 1);
 }
+
+TEST(Jay_Network_Test, Jay_Network_Get_Name_Set_Test)
+{
+  jay::network j1939_network{ "vcan0" };
+  std::vector<jay::name> names{ jay::name{ 0x1U }, jay::name{ 0x2U }, jay::name{ 0x3U } };
+
+  uint8_t address = 0x80;
+  for (auto n : names) { j1939_network.insert(n, address++); }
+
+  auto name_set = j1939_network.get_name_set();
+  ASSERT_EQ(name_set.size(), names.size());
+  for (auto n : names) { ASSERT_TRUE(name_set.count(n)); }
+}


### PR DESCRIPTION
## Summary
- verify `get_name_set()` returns expected names
- add test exercising multi-packet BAM send in transport protocol
- include new test file in test build
- fix TP data frames to use `PGN_TP_DT`

## Testing
- `cmake ..` *(fails: required package canary not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d62d3f5c8320a3e90c3950b53bcd