### PR TITLE
Rename address manager and state machine classes

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -31,7 +31,7 @@ int main()
 
   auto vcan0_network = std::make_shared<jay::network>("vcan0");
   auto conn = std::make_shared<jay::j1939_connection>(io_layer, vcan0_network);
-  jay::address_manager addr_mngr{ io_layer, jay::name{ 0x7758 }, vcan0_network };
+  jay::address_claimer addr_mngr{ io_layer, jay::name{ 0x7758 }, vcan0_network };
 
   // ------- Connect components with callbacks ------- //
 
@@ -39,7 +39,7 @@ int main()
 
   conn->on_start([](auto) { std::cout << "Listening for can messages..." << std::endl; });
   conn->on_close([](auto) { std::cout << "J1939 Connection closed" << std::endl; });
-  conn->on_read([&addr_mngr](auto frame) { addr_mngr.address_claim(jay::address_claimer::ev_address_claim{ frame.payload, frame.header.source_address() }); });
+  conn->on_read([&addr_mngr](auto frame) { addr_mngr.address_claim(jay::address_state_machine::ev_address_claim{ frame.payload, frame.header.source_address() }); });
   conn->on_send([](auto frame) { std::cout << "Sent frame: " << frame.to_string() << std::endl; });
   conn->on_error([](auto what, auto ec) { std::cout << what << " " << ec.message() << std::endl; });
 

--- a/include/jay/address_state_machine.hpp
+++ b/include/jay/address_state_machine.hpp
@@ -27,10 +27,10 @@ namespace jay {
  * @note Each state machine is responsible for only one name address pair
  * @note The state machine does not (cant?) manage delays / timeouts internally
  */
-class address_claimer
+class address_state_machine
 {
 public:
-  using self = address_claimer;
+  using self = address_state_machine;
 
   /**
    * @brief Callbacks for generating outputs
@@ -50,14 +50,14 @@ public:
    * @brief Constructor
    * @param name to get an address for
    */
-  explicit address_claimer(name name) : name_(name), callbacks_() {}
+  explicit address_state_machine(name name) : name_(name), callbacks_() {}
 
   /**
    * @brief Constructor
    * @param name to get an address for
    * @param callbacks
    */
-  address_claimer(name name, callbacks &&callbacks) : name_(name), callbacks_(std::move(callbacks))
+  address_state_machine(name name, callbacks &&callbacks) : name_(name), callbacks_(std::move(callbacks))
   {
     assert(callbacks_.on_address);
     assert(callbacks_.on_lose_address);

--- a/tests/address_claimer_test.cpp
+++ b/tests/address_claimer_test.cpp
@@ -22,7 +22,7 @@ protected:
   explicit AddressClaimerTest()
   {
     j1939_network = std::make_shared<jay::network>("vcan0");
-    addr_mng = new jay::address_manager(io, local_name, j1939_network);
+    addr_mng = new jay::address_claimer(io, local_name, j1939_network);
     /// Outputs used for debugging
     addr_mng->on_frame([this](jay::frame frame) -> void {
       // std::cout << "Sending: " << frame.to_string() << std::endl;
@@ -50,7 +50,7 @@ public:
   boost::asio::io_context io{};
   jay::name local_name{ 0xFF };
   std::shared_ptr<jay::network> j1939_network;
-  jay::address_manager *addr_mng{};
+  jay::address_claimer *addr_mng{};
 };
 
 TEST_F(AddressClaimerTest, Jay_Address_Claimer_Test)
@@ -59,7 +59,7 @@ TEST_F(AddressClaimerTest, Jay_Address_Claimer_Test)
   ASSERT_EQ(frame_queue.size(), 0);
 
   // Return cannot claim address
-  addr_mng->address_request(jay::address_claimer::ev_address_request{});
+  addr_mng->address_request(jay::address_state_machine::ev_address_request{});
 
   // Enough time for timeout event to trigger
   io.run_for(std::chrono::milliseconds(260));
@@ -77,7 +77,7 @@ TEST_F(AddressClaimerTest, Jay_Address_Claimer_Test)
   // Does nothing as we have not started claiming address
   jay::name controller_1{ 0xa00c81045a20021b };
   std::uint8_t address_1{ 0x10U };
-  addr_mng->address_claim(jay::address_claimer::ev_address_claim{ controller_1, address_1 });
+  addr_mng->address_claim(jay::address_state_machine::ev_address_claim{ controller_1, address_1 });
 
   // Enough time for timeout event to trigger
   io.run_for(std::chrono::milliseconds(260));
@@ -108,7 +108,7 @@ TEST_F(AddressClaimerTest, Jay_Address_Claimer_Test)
   ASSERT_EQ(j1939_network->get_address(local_name), address_0);
 
   // Should return address claim frame on request
-  addr_mng->address_request(jay::address_claimer::ev_address_request{});
+  addr_mng->address_request(jay::address_state_machine::ev_address_request{});
 
   io.run_for(std::chrono::milliseconds(20));
   io.restart();
@@ -125,7 +125,7 @@ TEST_F(AddressClaimerTest, Jay_Address_Claimer_Test)
     j1939_network->insert(i, i);
 
     // Conflicting claim should change to new address
-    addr_mng->address_claim(jay::address_claimer::ev_address_claim{ jay::name{ i }, i });
+    addr_mng->address_claim(jay::address_state_machine::ev_address_claim{ jay::name{ i }, i });
 
     io.run_for(std::chrono::milliseconds(260));// Give timeout time to trigger
     io.restart();
@@ -145,7 +145,7 @@ TEST_F(AddressClaimerTest, Jay_Address_Claimer_Test)
   j1939_network->insert(jay::J1939_MAX_UNICAST_ADDR, jay::J1939_MAX_UNICAST_ADDR);
 
   // Conflicting claim should change to new address
-  addr_mng->address_claim(jay::address_claimer::ev_address_claim{
+  addr_mng->address_claim(jay::address_state_machine::ev_address_claim{
     jay::name{ jay::J1939_MAX_UNICAST_ADDR }, static_cast<std::uint8_t>(jay::J1939_MAX_UNICAST_ADDR) });
 
   io.run_for(std::chrono::milliseconds(260));// Give timeout time to trigger

--- a/tests/network_process_test.cpp
+++ b/tests/network_process_test.cpp
@@ -31,15 +31,15 @@ TEST_F(NetworkProcessTest, ManualProcess)
   boost::asio::io_context ctx;
   std::queue<jay::frame> out_queue{};
 
-  jay::address_manager a1{ ctx, {0xAFFU}, network };
+  jay::address_claimer a1{ ctx, {0xAFFU}, network };
   a1.on_frame([&](jay::frame f) { out_queue.push(f); });
 
-  jay::address_manager a2{ ctx, {0xBFFU}, network };
+  jay::address_claimer a2{ ctx, {0xBFFU}, network };
   a2.on_frame([&](jay::frame f) { out_queue.push(f); });
 
   // simulate address request broadcast
-  a1.address_request(jay::address_claimer::ev_address_request{});
-  a2.address_request(jay::address_claimer::ev_address_request{});
+  a1.address_request(jay::address_state_machine::ev_address_request{});
+  a2.address_request(jay::address_state_machine::ev_address_request{});
   ctx.run_for(std::chrono::milliseconds(300));
   ctx.restart();
   ASSERT_EQ(out_queue.size(), 2);


### PR DESCRIPTION
## Summary
- rename wrapper class `address_manager` to `address_claimer`
- rename state machine class `address_claimer` to `address_state_machine`
- update examples and tests to use the new class names

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: Jay_Frame_Test.Jay_Frame_Sync_Send_Test, Jay_Frame_Test.Jay_Frame_Sync_SendTo_Test)*

------
https://chatgpt.com/codex/tasks/task_e_6857d759d7fc8320b66454446afe30f9