### PR TITLE
Fix TP error handling

### DIFF
--- a/tests/address_claimer_test.cpp
+++ b/tests/address_claimer_test.cpp
@@ -22,7 +22,7 @@ protected:
   explicit AddressClaimerTest()
   {
     j1939_network = std::make_shared<jay::network>("vcan0");
-    addr_mng = new jay::address_claimer(io, local_name, j1939_network);
+    addr_mng = new jay::address_claimer(io, local_name, *j1939_network);
     /// Outputs used for debugging
     addr_mng->on_frame([this](jay::frame frame) -> void {
       // std::cout << "Sending: " << frame.to_string() << std::endl;

--- a/tests/network_process_test.cpp
+++ b/tests/network_process_test.cpp
@@ -31,10 +31,10 @@ TEST_F(NetworkProcessTest, ManualProcess)
   boost::asio::io_context ctx;
   std::queue<jay::frame> out_queue{};
 
-  jay::address_claimer a1{ ctx, {0xAFFU}, network };
+  jay::address_claimer a1{ ctx, {0xAFFU}, *network };
   a1.on_frame([&](jay::frame f) { out_queue.push(f); });
 
-  jay::address_claimer a2{ ctx, {0xBFFU}, network };
+  jay::address_claimer a2{ ctx, {0xBFFU}, *network };
   a2.on_frame([&](jay::frame f) { out_queue.push(f); });
 
   // simulate address request broadcast


### PR DESCRIPTION
## Summary
- abort when CTS is received without a matching session
- send aborts for invalid or unexpected DT frames
- fix unit test build after address_claimer interface update

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure` *(fails: AddressClaimerTest and others due to missing vcan interfaces)*

------
https://chatgpt.com/codex/tasks/task_e_6858b7c077348320a9e485880a2cb816