### PR TITLE
Fix address_claimer start logic

### DIFF
--- a/include/jay/address_claimer.hpp
+++ b/include/jay/address_claimer.hpp
@@ -148,6 +148,7 @@ public:
     if (!state_machine_.is(boost::sml::state<jay::address_state_machine::st_no_address>)) { return; }
 
     boost::asio::post(context_, [this, preferred_address]() -> void {
+      state_machine_.process_event(jay::address_state_machine::ev_restart{});
       state_machine_.process_event(jay::address_state_machine::ev_start_claim{ preferred_address });
     });
   }

--- a/include/jay/address_state_machine.hpp
+++ b/include/jay/address_state_machine.hpp
@@ -150,6 +150,14 @@ public:
   {
   };
 
+  /**
+   * @brief Event used to re-enter the no address state so that on_entry actions
+   *        can be triggered manually
+   */
+  struct ev_restart
+  {
+  };
+
 private:
   //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@//
   //@                             Guards                             @//
@@ -688,6 +696,7 @@ public:
       state<st_no_address> + event<ev_address_request>[guard_is_global_address_req{}] / act_send_cannot_claim{},
       state<st_no_address> + event<ev_start_claim>[guard_address_available{}] / act_set_pref_address{} = state<st_claiming>,
       state<st_no_address> + event<ev_start_claim>[guard_no_address_available{}] / act_send_cannot_claim{},
+      state<st_no_address> + event<ev_restart> = state<st_no_address>,
 
       // Claiming
       state<st_claiming> + on_entry<_> / act_begin_claiming_address{},

--- a/tests/address_claimer_test.cpp
+++ b/tests/address_claimer_test.cpp
@@ -104,10 +104,15 @@ TEST_F(AddressClaimerTest, Jay_Address_Claimer_Test)
   io.run_for(std::chrono::milliseconds(260));
   io.restart();
 
-  ASSERT_EQ(frame_queue.size(), 1);
+  ASSERT_EQ(frame_queue.size(), 2);
 
-  /// Address claim frame (modified: expect ADDRESS_CLAIM instead of REQUEST)
-  frame = frame_queue.back();
+  frame = frame_queue.front();
+  ASSERT_EQ(frame.header.pdu_format(), jay::PF_REQUEST);
+  ASSERT_EQ(frame.header.pdu_specific(), jay::J1939_NO_ADDR);
+  ASSERT_EQ(frame.header.source_address(), jay::J1939_IDLE_ADDR);
+  frame_queue.pop();
+
+  frame = frame_queue.front();
   ASSERT_EQ(frame.header.pdu_format(), jay::PF_ADDRESS_CLAIM);
   ASSERT_EQ(frame.header.pdu_specific(), jay::J1939_NO_ADDR);
   ASSERT_EQ(frame.header.source_address(), address_0);

--- a/tests/network_manager_test.cpp
+++ b/tests/network_manager_test.cpp
@@ -98,7 +98,9 @@ TEST_F(NetworkManagerTest, Jay_Network_Manager_Test)
   context.run_for(std::chrono::milliseconds(300));// Enough time for timeout to trigger
   context.restart();
 
-  ASSERT_EQ(frame_queue.size(), 2);
+  ASSERT_EQ(frame_queue.size(), 4);
+  frame_queue.pop();
+  frame_queue.pop();
   frame_queue.pop();
   frame_queue.pop();
 

--- a/tests/network_process_test.cpp
+++ b/tests/network_process_test.cpp
@@ -51,6 +51,6 @@ TEST_F(NetworkProcessTest, ManualProcess)
   a2.start_address_claim(0x11);
   ctx.run_for(std::chrono::milliseconds(300));
   ctx.restart();
-  ASSERT_EQ(out_queue.size(), 2);
+  ASSERT_EQ(out_queue.size(), 4);
 }
 


### PR DESCRIPTION
## Summary
- trigger st_no_address entry by emitting a restart event
- update unit tests for the new request frame before claiming

## Testing
- `cmake --build .`
- `ctest --output-on-failure` *(fails: Jay_Frame_Test.Jay_Frame_Sync_Send_Test, Jay_Frame_Test.Jay_Frame_Sync_SendTo_Test)*

------
https://chatgpt.com/codex/tasks/task_e_68609caa31bc8320a725d609a4db4477